### PR TITLE
Pin docker images, use distroless, and run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/golang:bullseye@sha256:8d717e8a7fa8035f5cfdcdc86811ffd53b7bb17542f419f2a121c4c7533d29ee as builder
-ADD . /app
+COPY . /app
 WORKDIR /app
 RUN GOOS=linux GOARCH=amd64 go build -o dist/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang
+FROM docker.io/golang:bullseye@sha256:8d717e8a7fa8035f5cfdcdc86811ffd53b7bb17542f419f2a121c4c7533d29ee as builder
+ADD . /app
+WORKDIR /app
+RUN GOOS=linux GOARCH=amd64 go build -o dist/
 
-ADD . /go/src/github.com/Lukasa/mkcert
-
-RUN go install github.com/Lukasa/mkcert
-
-ENTRYPOINT /go/bin/mkcert
-
+FROM gcr.io/distroless/static-debian11@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97
+COPY --from=builder /app/dist/mkcert /bin/mkcert
+USER 1001
+CMD ["/bin/mkcert"]
 EXPOSE 8080

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Lukasa/mkcert
+
+go 1.17


### PR DESCRIPTION
Hi there! I stumbled across this repo and noticed how important it is given [certifi pulls from here](https://github.com/certifi/python-certifi/blob/ff23c47fe88b21efa8099d9f957f91bcd4089fbd/Makefile#L2), which is used by python-requests (as you know :)) Relevant as always: https://xkcd.com/2347/

This PR helps to increase the security of the server running mkcert by a) making it harder for attackers to break *into* the container and b) making it hard to break *out* of the container.

To prevent attackers from breaking *into* the container, I've upgraded the golang version to 1.17 and moved to use a [distroless container](https://github.com/GoogleContainerTools/distroless). Distroless containers don't contain shells or other binaries that make juicy targets for RCE attacks. I also pinned the images by SHA which is recommended to avoid the upstream from changing the `golang:latest` tag maliciously.

To prevent attackers from breaking *out* of the container, I made the container run as a non-root user. Every major set of security recommendations for Kubernetes recommends that containers running as the root user should be minimized to prevent container breakouts ([NSA/CISA Kubernetes Hardening Guide, page 7](https://media.defense.gov/2021/Aug/03/2002820425/-1/-1/1/CTR_KUBERNETES%20HARDENING%20GUIDANCE.PDF); [CIS Benchmarks for Kubernetes section 5.2.6](https://workbench.cisecurity.org/sections/639550/recommendations/1047767); [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)). This would help if an attacker did break into mkcert since they might choose to break out of the container and gain persistence on the server in order to attack at a later time.

#### Other stuff

I'd also recommend running the container with [the  `--read-only` flag](https://docs.docker.com/engine/reference/commandline/run/#options) if you aren't already. That might prevent someone from modifying the container's cacerts while it's running.

Finally, I ran an nmap on mkcert.org and noticed port 8080 is open, meaning you can bypass the Caddy server and access the API directly. I can't think of a specific risk that that poses, but it's probably best to close that port just to be safe.