### PR TITLE
Update to golang 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM docker.io/golang:bullseye@sha256:8d717e8a7fa8035f5cfdcdc86811ffd53b7bb17542f419f2a121c4c7533d29ee as builder
+FROM docker.io/golang:1.23 as builder
 COPY . /app
 WORKDIR /app
+RUN go test ./...
 RUN GOOS=linux GOARCH=amd64 go build -o dist/
 
-FROM gcr.io/distroless/static-debian11@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97
+FROM gcr.io/distroless/static-debian12:latest
 COPY --from=builder /app/dist/mkcert /bin/mkcert
 USER 1001
 CMD ["/bin/mkcert"]

--- a/body/parser.go
+++ b/body/parser.go
@@ -17,13 +17,13 @@ package body
 import (
 	"encoding/json"
 	"errors"
-	"github.com/Lukasa/mkcert/certs"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime"
 	"mime/multipart"
 	"strings"
+
+	"github.com/Lukasa/mkcert/certs"
 )
 
 var (
@@ -98,7 +98,7 @@ func ParseMultipartBody(f io.Reader, boundary string) ([]string, []*certs.Certif
 				label = labelVals[0]
 			}
 
-			body, err := ioutil.ReadAll(p)
+			body, err := io.ReadAll(p)
 			if err != nil {
 				log.Printf("Unexpected IO error: %v.\n", err)
 				return nil, nil, err

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Lukasa/mkcert
 
-go 1.17
+go 1.23

--- a/main.go
+++ b/main.go
@@ -17,14 +17,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Lukasa/mkcert/certs"
 	"io"
 	"log"
 	"net/http"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Lukasa/mkcert/certs"
 )
 
 const CERT_URL = "https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt"
@@ -237,9 +237,6 @@ func listAllCerts(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	// Before we do anything, TURN ON THE CPUS.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Start the certificate update loop.
 	go certUpdateLoop()
 


### PR DESCRIPTION
This PR primarily updates the code to use golang 1.23.

Previously in #15 I pinned the docker images, but my security advice has changed on this topic in the last 2 years. Pinning base images is only good for repos that are automatically updated with something like Dependabot or Renovate. For a repo like this, I think it makes more sense to use floating tags like `latest` so you get the latest patches every time you rebuild. 

Besides, if I pinned the golang image today, we'd be pinning some known CVEs already: https://hub.docker.com/layers/library/golang/latest/images/sha256-d0aac08f954c29a6c42b8fa15f590467343aa44322b5fa059227d554b07d6e99?context=explore

Other changes:
* Removed the manual setting of GOMAXPROCS. That's only needed for golang < 1.5: https://stackoverflow.com/a/17853959
* Migrated away from `ioutil` which was deprecated in golang 1.16.
* Ran the tests inside the docker build. They run super quickly, so it doesn't really slow the build down, but it does avoid accidentally skipping the tests when deploying new versions (since there's no CI/CD).