### PR TITLE
fixes #19 -- correct handle certificate distrust date

### DIFF
--- a/certs/convert_mozilla_certdata.go
+++ b/certs/convert_mozilla_certdata.go
@@ -272,7 +272,11 @@ func OutputTrustedCerts(objects []*Object) (parsedCerts CertList) {
 				log.Fatalf("Unable to parse distrust after value '%s' for certificate on line %d, error %s", distrustAfter.value, cert.startingLine, err)
 			}
 
-			if time.Now().After(t) {
+			// The distrust date is for certificates issued after this date.
+			// The current maximum age of a WebPKI cert is 397 days, so if
+			// we're 398 days past the distrust date, it's impossible for
+			// there to be a valid cert.
+			if time.Now().After(t.Add(time.Hour * 24 * 398)) {
 				// This certificate is now distrusted.
 				continue
 			}


### PR DESCRIPTION
It is the date after which certificates issued by this root should not be trusted, not the date the root itself becomes untrusted for all certs.